### PR TITLE
Fix error in the ACS lab

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 azure-core==1.29.3
 azure-identity==1.14.0
-azure-search-documents==11.4.0b6
+azure-search-documents==11.4.0b8
 openai==0.27.9
 langchain==0.0.271
 tiktoken==0.4.0


### PR DESCRIPTION
The current version of azure-search-documents fails with:

"cannot import name 'HnswVectorSearchAlgorithmConfiguration' from 'azure.search.documents.indexes.models'"

The update fixes that error.