### PR TITLE
Roydemilde - version 8.0 (devcontainer)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # [Choice] .NET version: 7.0, 6.0, 3.1, 6.0-bullseye, 3.1-bullseye, 6.0-focal, 3.1-focal
 # See here for devcontainer tags: https://mcr.microsoft.com/v2/devcontainers/dotnet/tags/list
-ARG VARIANT="7.0-jammy"
+ARG VARIANT="8.0-jammy"
 FROM mcr.microsoft.com/vscode/devcontainers/dotnet:${VARIANT}
 
 # [Choice] Node.js version: none, lts/*, 18, 16, 14

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -10,7 +10,7 @@ services:
         # Update 'VARIANT' to pick an version of .NET: 6, 7.
         # Append -bullseye or -buster to pin to an OS version.
         # Use -bullseye variants on local arm64/Apple Silicon.
-        VARIANT: 7.0-jammy
+        VARIANT: 8.0-jammy
         # Options
         NODE_VERSION: "lts/*"
     environment:


### PR DESCRIPTION
Modified version to 8.0 dotnet in dockerfile and docker-compose to have 8.0 installed for the HOL S.K.