### PR TITLE
Read OPENAI_API_TYPE from Env in langchain.ipynb

### DIFF
--- a/labs/02-integrating-ai/03-Langchain/langchain.ipynb
+++ b/labs/02-integrating-ai/03-Langchain/langchain.ipynb
@@ -73,7 +73,7 @@
    "source": [
     "# Create an instance of Azure OpenAI\n",
     "llm = AzureChatOpenAI(\n",
-    "    openai_api_type = openai.api_type,\n",
+    "    openai_api_type = os.getenv(\"OPENAI_API_TYPE\"),\n",
     "    openai_api_version = os.getenv(\"OPENAI_API_VERSION\"),\n",
     "    openai_api_base = os.getenv(\"OPENAI_API_BASE\"),\n",
     "    openai_api_key = os.getenv(\"OPENAI_API_KEY\"),\n",


### PR DESCRIPTION
This pull request modifies the code in `langchain.ipynb` to use the value of the environment variable `OPENAI_API_TYPE` instead of the `openai.api_type` variable. This change improves the flexibility and configuration of the Azure OpenAI instance.

Main change:

* [`labs/02-integrating-ai/03-Langchain/langchain.ipynb`](diffhunk://#diff-b01247fe94a1cdc9474526b1a7d9a7830eee85c9b291d4d24560f14e53e1e27eL76-R76): Modified code to use the value of the environment variable `OPENAI_API_TYPE` instead of the `openai.api_type` variable.