### PR TITLE
fixing a small typo

### DIFF
--- a/labs/03-orchestration/02-Embeddings/embeddings.ipynb
+++ b/labs/03-orchestration/02-Embeddings/embeddings.ipynb
@@ -225,7 +225,7 @@
    "source": [
     "Now that we've initialised a model to create embeddings, let's go ahead and embed some documents.\n",
     "\n",
-    "As we did in the previous example, we'll use Langchain's built in loaders to read the documents from a directory."
+    "As we did in the previous example, we'll use Langchain's built-in loaders to read the documents from a directory."
    ]
   },
   {

--- a/labs/03-orchestration/02-Embeddings/embeddings.ipynb
+++ b/labs/03-orchestration/02-Embeddings/embeddings.ipynb
@@ -225,7 +225,7 @@
    "source": [
     "Now that we've initialised a model to create embeddings, let's go ahead and embed some documents.\n",
     "\n",
-    "As we did in the previous example, we'll use Langchain's builit in loaders to read the documents from a directory."
+    "As we did in the previous example, we'll use Langchain's built in loaders to read the documents from a directory."
    ]
   },
   {


### PR DESCRIPTION
Just fixing a small typo, and I think it should read "built-in" (with a hyphen).